### PR TITLE
Fix crash when ore dictionary ingredients are used in the alloy furnace

### DIFF
--- a/src/main/java/epicsquid/gadgetry/core/recipe/AlloyRecipe.java
+++ b/src/main/java/epicsquid/gadgetry/core/recipe/AlloyRecipe.java
@@ -35,9 +35,9 @@ public class AlloyRecipe extends RecipeBase {
     if (Loader.isModLoaded("jei")) {
       MinecraftForge.EVENT_BUS.register(new AlloyRecipeJEI());
     }
-    recipes.add(new AlloyRecipe(new ItemStack(RegistryManager.redmetal_ingot, 1), new ItemStack(Items.GOLD_INGOT, 1), new ItemStack(Items.REDSTONE, 1),
+    recipes.add(new AlloyRecipe(new ItemStack(RegistryManager.redmetal_ingot, 1), "ingotGold", new ItemStack(Items.REDSTONE, 1),
         ItemStack.EMPTY));
-    recipes.add(new AlloyRecipe(new ItemStack(RegistryManager.steel_ingot, 1), new ItemStack(Items.IRON_INGOT, 1), new ItemStack(Items.COAL, 1),
+    recipes.add(new AlloyRecipe(new ItemStack(RegistryManager.steel_ingot, 1), "ingotIron", new ItemStack(Items.COAL, 1),
         new ItemStack(Items.GUNPOWDER, 1)));
     recipes.add(new AlloyRecipe(new ItemStack(RegistryManager.silicon, 1), new ItemStack(Blocks.GLASS, 1), ItemStack.EMPTY, ItemStack.EMPTY));
     for (AlloyRecipe r : recipes) {

--- a/src/main/java/epicsquid/gadgetry/core/recipe/RecipeBase.java
+++ b/src/main/java/epicsquid/gadgetry/core/recipe/RecipeBase.java
@@ -68,6 +68,8 @@ public class RecipeBase {
         return false;
       }
     } else if (recipeInput instanceof OreStack) {
+      if (stack.isEmpty())
+        return ((OreStack) recipeInput).oreId.isEmpty();
       int id = OreDictionary.getOreID(((OreStack) recipeInput).oreId);
       int[] ids = OreDictionary.getOreIDs(stack);
       boolean hasMatch = false;
@@ -80,6 +82,8 @@ public class RecipeBase {
         return hasMatch;
       }
     } else if (recipeInput instanceof String) {
+      if (stack.isEmpty())
+        return ((String) recipeInput).isEmpty();
       int id = OreDictionary.getOreID((String) recipeInput);
       int[] ids = OreDictionary.getOreIDs(stack);
       boolean hasMatch = false;


### PR DESCRIPTION
Fixes #8. It also uses ore dictionary ingredients by default for the iron and gold ingot.